### PR TITLE
Download pyega3@0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -19,10 +19,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: "3.10"
+        architecture: "x64"
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Extract package name and version from branch name
       id: get_pkg_info
@@ -80,10 +83,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: "3.10"
+        architecture: "x64"
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/download-pyega3/Dockerfile
+++ b/download-pyega3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source https://github.com/edsu7/argo-data-submission
 LABEL org.opencontainers.image.authors Edmund Su (edmund.su@oicr.on.ca)
@@ -12,7 +12,7 @@ RUN mkdir /tools
 
 RUN pip3 install --upgrade pip
 
-RUN pip3 install pyega3
+RUN pip install pyega3
     
 ENV PATH="/tools:${PATH}"
 

--- a/download-pyega3/main.nf
+++ b/download-pyega3/main.nf
@@ -25,7 +25,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.1.3'
+version = '0.2.0'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo/argo-data-submission.download-pyega3'

--- a/download-pyega3/main.nf
+++ b/download-pyega3/main.nf
@@ -48,6 +48,7 @@ params.publish_dir = ""  // set to empty string will disable publishDir
 params.ega_id=''
 params.pyega3_ega_user=''
 params.pyega3_ega_pass=''
+params.connections=30
 
 
 process downloadPyega3 {
@@ -59,6 +60,7 @@ process downloadPyega3 {
 
   input:  // input, make update as needed
     val ega_id
+    val connections
     val dependency
 
   output:  // output, make update as needed
@@ -72,7 +74,7 @@ process downloadPyega3 {
     mkdir -p ${ega_id}
     python3 /tools/main.py \\
     	-f ${ega_id} \\
-      -c ${params.cpus} \\
+      -c ${connections} \\
     	-o \$PWD \\
     	> download.log 2>&1
     
@@ -85,6 +87,7 @@ process downloadPyega3 {
 workflow {
   downloadPyega3(
     params.ega_id,
+    params.connections,
     true
   )
 }

--- a/download-pyega3/main.nf
+++ b/download-pyega3/main.nf
@@ -39,7 +39,7 @@ params.container_registry = ""
 params.container_version = ""
 params.container = ""
 
-params.cpus = 1
+params.cpus = 2
 params.mem = 1  // GB
 params.publish_dir = ""  // set to empty string will disable publishDir
 
@@ -70,8 +70,9 @@ process downloadPyega3 {
     export PYEGA3_EGA_USER=${params.pyega3_ega_user}
     export PYEGA3_EGA_PASS=${params.pyega3_ega_pass}
     mkdir -p ${ega_id}
-    python3.6 /tools/main.py \\
+    python3 /tools/main.py \\
     	-f ${ega_id} \\
+      -c ${params.cpus} \\
     	-o \$PWD \\
     	> download.log 2>&1
     

--- a/download-pyega3/main.py
+++ b/download-pyega3/main.py
@@ -41,6 +41,7 @@ def main():
     parser = argparse.ArgumentParser(description='Download files from EGA pyega3 server')
     parser.add_argument('-f', '--file_name', dest="file_name", help="EGA file name", required=True)
     parser.add_argument('-o', '--output', dest='output', help="Output file directory", required=True)
+    parser.add_argument('-c', '--connections', dest='connections', help="Number of connections to use", required=True)
 
     results = parser.parse_args()
 
@@ -70,7 +71,7 @@ def main():
         
         # Download process
         subprocess.call(
-            ["pyega3","-cf",cred_file,"fetch",results.file_name,"--delete-temp-files"]
+            ["pyega3","--connections",results.connections,"-cf",cred_file,"fetch",results.file_name,"--delete-temp-files"]
         )
         
         # Check if successful

--- a/download-pyega3/pkg.json
+++ b/download-pyega3/pkg.json
@@ -1,6 +1,6 @@
 {
     "name": "download-pyega3",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "EGA download client",
     "main": "main.nf",
     "deprecated": false,

--- a/download-pyega3/tests/checker.nf
+++ b/download-pyega3/tests/checker.nf
@@ -29,7 +29,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.1.3'
+version = '0.2.0'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo/argo-data-submission.download-pyega3'

--- a/download-pyega3/tests/checker.nf
+++ b/download-pyega3/tests/checker.nf
@@ -43,7 +43,7 @@ params.container_version = ""
 params.container = ""
 
 // tool specific parmas go here, add / change as needed
-
+params.connections=30
 
 include { downloadPyega3 } from '../main.nf'
 
@@ -79,6 +79,7 @@ workflow checker {
   main:
     downloadPyega3(
       ega_id,
+      params.connections,
       true
     )
 

--- a/download-pyega3/tests/config.json
+++ b/download-pyega3/tests/config.json
@@ -1,0 +1,4 @@
+{
+    "username" : "ega-test-data@ebi.ac.uk",
+    "password" : "egarocks"
+}


### PR DESCRIPTION
Notes:
- tied # of `connections` to `params.cpu`, do we want them to be separate?
- `EGAF00005007329` in `local-test-job-pyega3.json` is too small so pyega3 will default to `1` `connection`
- Can instead use `EGAF00001753734`. Check `pyega3_output.log` for connections. Download does not have to complete
```
[2022-12-16 16:40:46 -0500] pyEGA3 - EGA python client version 5.0.1 (https://github.com/EGA-archive/ega-download-client)
[2022-12-16 16:40:46 -0500] Parts of this software are derived from pyEGA (https://github.com/blachlylab/pyega) by James Blachly
[2022-12-16 16:40:46 -0500] Python version : 3.9.15
[2022-12-16 16:40:46 -0500] OS version : Darwin Darwin Kernel Version 21.6.0: Thu Sep 29 20:12:57 PDT 2022; root:xnu-8020.240.7~1/RELEASE_X86_64
[2022-12-16 16:40:46 -0500] MacOS version : 12.6.1
[2022-12-16 16:40:46 -0500] Server URL: https://ega.ebi.ac.uk:8443/v2
[2022-12-16 16:40:46 -0500] Session-Id: 1631225536
[2022-12-16 16:40:47 -0500] 
[2022-12-16 16:40:47 -0500] Authentication success for user 'ega-test-data@ebi.ac.uk'
[2022-12-16 16:40:47 -0500] File Id: 'EGAF00001753734'(45030910198 bytes).
[2022-12-16 16:40:47 -0500] Total space : 465.63 GiB
[2022-12-16 16:40:47 -0500] Used space : 286.58 GiB
[2022-12-16 16:40:47 -0500] Free space : 179.05 GiB
[2022-12-16 16:40:47 -0500] Download starting [using 4 connection(s), file size 45030910182 and chunk length 104857600]...
```